### PR TITLE
Increase performance and decrease memory usage

### DIFF
--- a/lib/unicode/display_width.rb
+++ b/lib/unicode/display_width.rb
@@ -3,11 +3,13 @@ require_relative 'display_width/index'
 
 module Unicode
   module DisplayWidth
+    DEPTHS = [0x10000, 0x1000, 0x100, 0x10].freeze
+
     def self.of(string, ambiguous = 1, overwrite = {})
-      res = string.unpack('U*').inject(0){ |total_width, codepoint|
+      res = string.unpack('U*'.freeze).inject(0){ |total_width, codepoint|
         index_or_value = INDEX
         codepoint_depth_offset = codepoint
-        [0x10000, 0x1000, 0x100, 0x10].each{ |depth|
+        DEPTHS.each{ |depth|
           index_or_value         = index_or_value[codepoint_depth_offset / depth]
           codepoint_depth_offset = codepoint_depth_offset % depth
           break unless index_or_value.is_a? Array


### PR DESCRIPTION
I was doing some memory profiling on RuboCop and noticed some large memory usage from the `display_width.rb` file. With a couple of small tweaks, I was able to reduce memory consumption by 80% (3421560 bytes down to 651456 bytes), and I was able to increase performance by 20%.

```ruby
# Before modification
[2] pry(main)> Benchmark.ips do |x|
[2] pry(main)*   x.report('unicode') { 'À'.display_width }
[2] pry(main)*   x.report('non unicode') { 'A'.display_width }
[2] pry(main)*   x.compare!
[2] pry(main)* end  
Warming up --------------------------------------
             unicode    61.964k i/100ms
         non unicode    54.255k i/100ms
Calculating -------------------------------------
             unicode    731.129k (± 2.6%) i/s -      3.656M in   5.003809s
         non unicode    622.622k (± 4.2%) i/s -      3.147M in   5.064003s

Comparison:
             unicode:   731129.3 i/s
         non unicode:   622622.2 i/s - 1.17x  slower


# After modification
[3] pry(main)> Benchmark.ips do |x|
[3] pry(main)*   x.report('unicode') { 'À'.display_width }
[3] pry(main)*   x.report('non unicode') { 'A'.display_width }
[3] pry(main)*   x.compare!
[3] pry(main)* end  
Warming up --------------------------------------
             unicode    75.780k i/100ms
         non unicode    64.758k i/100ms
Calculating -------------------------------------
             unicode    901.646k (± 3.0%) i/s -      4.547M in   5.047534s
         non unicode    751.460k (± 4.2%) i/s -      3.756M in   5.008645s

Comparison:
             unicode:   901646.3 i/s
         non unicode:   751460.5 i/s - 1.20x  slower

[4] pry(main)> 731129.3 / 901646.3
=> 0.8108826044092899
[5] pry(main)> 622622.2 / 751460.5
=> 0.8285494713294976
```

These tests were run using Ruby 2.3.3.