### PR TITLE
source file not UTF-8 coding failed

### DIFF
--- a/lib/unicode/display_width.rb
+++ b/lib/unicode/display_width.rb
@@ -6,7 +6,7 @@ module Unicode
     DEPTHS = [0x10000, 0x1000, 0x100, 0x10].freeze
 
     def self.of(string, ambiguous = 1, overwrite = {})
-      res = string.unpack('U*'.freeze).inject(0){ |total_width, codepoint|
+      res = string.codepoints.inject(0){ |total_width, codepoint|
         index_or_value = INDEX
         codepoint_depth_offset = codepoint
         DEPTHS.each{ |depth|


### PR DESCRIPTION
if source file not encoding by UTF-8, 
`require 'unicode/display_width'`  will failed , 
raise `malformed UTF-8 character (ArgumentError)`