### PR TITLE
Updates 'Gem.gunzip' to 'Gem::Util.gunzip'

### DIFF
--- a/lib/unicode/display_width/index.rb
+++ b/lib/unicode/display_width/index.rb
@@ -2,6 +2,6 @@ require_relative 'constants'
 
 module Unicode
   module DisplayWidth
-    INDEX = Marshal.load(Gem.gunzip(File.binread(INDEX_FILENAME)))
+    INDEX = Marshal.load(Gem::Util.gunzip(File.binread(INDEX_FILENAME)))
   end
 end


### PR DESCRIPTION
Gem.gunzip is deprecated, this will fix the deprecation and should have no major effect on code usage. Full deprecation message is: 

`NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01.`