### PR TITLE
Only ship the necessary lib files with the gem artifact

### DIFF
--- a/unicode-display_width.gemspec
+++ b/unicode-display_width.gemspec
@@ -6,10 +6,10 @@ Gem::Specification.new do |s|
   s.version     = Unicode::DisplayWidth::VERSION
   s.authors     = ["Jan Lelis"]
   s.email       = "mail@janlelis.de"
-  s.homepage    = "http://github.com/janlelis/unicode-display_width"
+  s.homepage    = "https://github.com/janlelis/unicode-display_width"
   s.summary = "Determines the monospace display width of a string in Ruby."
   s.description =  "[Unicode #{Unicode::DisplayWidth::UNICODE_VERSION}] Determines the monospace display width of a string using EastAsianWidth.txt, Unicode general category, and other data."
-  s.files = Dir.glob(%w[{lib,spec}/**/*.rb [A-Z]*.{txt,rdoc} data/display_width.marshal.gz]) + %w{Rakefile unicode-display_width.gemspec}
+  s.files = Dir.glob(%w[{lib,data}/**/*])
   s.extra_rdoc_files = ["README.md", "MIT-LICENSE.txt", "CHANGELOG.md"]
   s.license = 'MIT'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
This trims out of the spec and development files from the gem artifact.
These aren't necessary for the use of the library and only increase the
on disk size of ruby installs.

Signed-off-by: Tim Smith <tsmith@chef.io>