### PR TITLE
Added a reference to the Golang version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Replace "一" with the actual string to measure
 - JavaScript: https://github.com/mycoboco/wcwidth.js
 - C: https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
 - C for Julia: https://github.com/JuliaLang/utf8proc/issues/2
+- Golang: https://github.com/rivo/uniseg
 
 See [unicode-x](https://github.com/janlelis/unicode-x) for more Unicode related micro libraries.
 


### PR DESCRIPTION
There are a whole bunch of wcwidth implementations in different languages but I find that yours has the best explanation of what it actually does. I used this as a starting point for my implementation in Golang which, if you don't mind, could be added to your README with this PR.

If you're interested, [here](https://pkg.go.dev/github.com/rivo/uniseg#hdr-Monospace_Width) is an explanation of how I calculate the widths of characters.