### PR TITLE
Fix to run CI with Ruby 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - 3.1
-        - 3.0
-        - 2.7
+        - '3.1'
+        - '3.0'
+        - '2.7'
         - jruby
         - truffleruby
         os:
@@ -34,9 +34,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - 3.1
-        - 3.0
-        - 2.7
+        - '3.1'
+        - '3.0'
+        - '2.7'
         - jruby
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
Using 3.0 without quotes, ruby/setup-ruby will use 3.1 instead of 3.0.
To avoid similar parsing issues, all version numbers are enclosed in quotes.
Please see the following for more details.
- https://github.com/ruby/setup-ruby/issues/252
- https://github.com/actions/runner/issues/849