### PR TITLE
Optimize for ASCII-only strings without control symbols

### DIFF
--- a/lib/unicode/display_width.rb
+++ b/lib/unicode/display_width.rb
@@ -8,6 +8,9 @@ module Unicode
     DEPTHS = [0x10000, 0x1000, 0x100, 0x10].freeze
 
     def self.of(string, ambiguous = 1, overwrite = {}, options = {})
+      # Optimization for ASCII-only strings without control symbols.
+      return string.size if overwrite.empty? && string.ascii_only? && !string.match?(/[[:cntrl:]]/)
+
       res = string.codepoints.inject(0){ |total_width, codepoint|
         index_or_value = INDEX
         codepoint_depth_offset = codepoint


### PR DESCRIPTION
This gem takes quite some time to run in rubocop (see https://github.com/rubocop/rubocop/pull/11373 for the details).
Since 99.9% of the strings are ASCII-only, we can optimize for this case.

### Benchmarks
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem "benchmark-ips"
  gem "unicode-display_width"
end

module Unicode
  class DisplayWidth
    def self.of_optimized(string, ambiguous = 1, overwrite = {}, options = {})
      return string.size if overwrite.empty? && string.ascii_only? && !string.match?(/[[:cntrl:]]/)

      of(string, ambiguous, overwrite, options)
    end
  end
end

str = "foobar" * 10 + "\n"

Benchmark.ips do |x|
  x.report("original") do
    Unicode::DisplayWidth.of(str)
  end

  x.report("optimized") do
    Unicode::DisplayWidth.of2(str)
  end

  x.compare!
end
```

For `str = "foobar"`
```
Warming up --------------------------------------
            original    15.441k i/100ms
           optimized   335.122k i/100ms
Calculating -------------------------------------
            original    155.966k (± 1.1%) i/s -    787.491k in   5.049718s
           optimized      3.451M (± 1.2%) i/s -     17.426M in   5.051001s

Comparison:
           optimized:  3450590.1 i/s
            original:   155966.4 i/s - 22.12x  (± 0.00) slower
```

For `str = "foobar\n"`
```
Warming up --------------------------------------
            original    10.522k i/100ms
           optimized    12.068k i/100ms
Calculating -------------------------------------
            original    118.648k (±11.5%) i/s -    578.710k in   5.037799s
           optimized    113.190k (± 9.7%) i/s -    567.196k in   5.072381s

Comparison:
            original:   118648.2 i/s
           optimized:   113190.3 i/s - same-ish: difference falls within error
```

For `str = "foobar" * 10`
```
Warming up --------------------------------------
            original     1.556k i/100ms
           optimized   286.015k i/100ms
Calculating -------------------------------------
            original     16.725k (± 0.9%) i/s -     84.024k in   5.024348s
           optimized      2.864M (± 1.0%) i/s -     14.587M in   5.094351s

Comparison:
           optimized:  2863627.4 i/s
            original:    16724.8 i/s - 171.22x  (± 0.00) slower
```

For `str = "foobar" * 10 + "\n"`
```
Warming up --------------------------------------
            original     1.429k i/100ms
           optimized     1.640k i/100ms
Calculating -------------------------------------
            original     15.553k (± 5.8%) i/s -     78.595k in   5.071250s
           optimized     15.825k (± 4.2%) i/s -     80.360k in   5.087199s

Comparison:
           optimized:    15825.0 i/s
            original:    15553.2 i/s - same-ish: difference falls within error
```

Note: This gem declares its support for ruby >= 1.9.3 (from the `.gespec` file), but CI is against >= 2.7. I used `Regexp#match?` method, which is not supported in ruby < 2.4.0. How to proceed?