### PR TITLE
Handle invalid encoded strings

### DIFF
--- a/lib/unicode/display_width.rb
+++ b/lib/unicode/display_width.rb
@@ -47,7 +47,14 @@ module Unicode
 
     # Returns monospace display width of string
     def self.of(string, ambiguous = nil, overwrite = nil, old_options = {}, **options)
-      string = string.encode(Encoding::UTF_8) unless string.encoding == Encoding::UTF_8
+      # Binary strings don't make much sense when calculating display width.
+      # Assume it's valid UTF-8
+      if string.encoding == Encoding::BINARY && !string.force_encoding(Encoding::UTF_8).valid_encoding?
+        # Didn't work out, go back to binary
+        string.force_encoding(Encoding::BINARY)
+      end
+
+      string = string.encode(Encoding::UTF_8, invalid: :replace, undef: :replace) unless string.encoding == Encoding::UTF_8
       options = normalize_options(string, ambiguous, overwrite, old_options, **options)
 
       width = 0
@@ -236,4 +243,3 @@ module Unicode
     end
   end
 end
-

--- a/spec/display_width_spec.rb
+++ b/spec/display_width_spec.rb
@@ -183,6 +183,17 @@ describe 'Unicode::DisplayWidth.of' do
     it 'works with non-utf8 Unicode encodings' do
       expect( 'À'.encode("UTF-16LE").display_width ).to eq 1
     end
+
+    it 'works with a string that is invalid in its encoding' do
+      s = "\x81\x39".dup.force_encoding(Encoding::SHIFT_JIS)
+
+      # Would print as �9 on the terminal
+      expect( s.display_width ).to eq 2
+    end
+
+    it 'works with a binary encoded string that is valid in UTF-8' do
+      expect( '€'.b.display_width ).to eq 1
+    end
   end
 
   describe '[emoji]' do


### PR DESCRIPTION
When trying to calculate the width of such strings, it would previously crash with either `Encoding::InvalidByteSequenceError` or `Encoding::UndefinedConversionError`. Totally invalid characters are now simply replaced with a replacement character when converting to UTF8.

Especially binary encoded strings (i.e. no encoding) don't make much sense but at least it doesn't crash now and tries to return a sensible default (assume the string is actually valid UTF8

This if for https://github.com/rubocop/rubocop/issues/13618, where such strings started to fail after `unicode-display_width` v3.