### PR TITLE
Memoize `EmojiSupport.recommended`

### DIFF
--- a/lib/unicode/display_width/emoji_support.rb
+++ b/lib/unicode/display_width/emoji_support.rb
@@ -1,5 +1,4 @@
-# require "rbconfig"
-# RbConfig::CONFIG["host_os"] =~ /mswin|mingw/ # windows
+# frozen_string_literal: true
 
 module Unicode
   class DisplayWidth
@@ -13,6 +12,10 @@ module Unicode
       # Please note: Many terminals do not set any ENV vars,
       # maybe CSI queries can help?
       def self.recommended
+        @recommended ||= _recommended
+      end
+
+      def self._recommended
         if ENV["CI"]
           return :rqi
         end


### PR DESCRIPTION
It's a simple function and I believe the result is not supposed to change at runtime. Strings were not frozen, so it made a bunch of useless allocations too.

I found this method while benchmarking, which was unexpected.

Some basic numbers:
```rb
# frozen_string_literal: true

require 'unicode/display_width'
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report do
    Unicode::DisplayWidth.of("foo")
  end

  x.compare!
end
```

Old gives `207.779k` iterations per second, while new one is `427.344k`. So more than 2x faster for basic cases